### PR TITLE
dependency to go-kinesis updated

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -9,7 +9,7 @@
 		{
 			"ImportPath": "github.com/rewardStyle/go-kinesis",
 			"Comment": "1.0.1-21-g7e55cce",
-			"Rev": "7e55ccefa23a47dd786058b7fbfb62f5c5ac34a5"
+			"Rev": "06b9508b531901108d306a988d7a47532d4ca2a0"
 		},
 		{
 			"ImportPath": "github.com/smartystreets/assertions",


### PR DESCRIPTION
Updated dependency for rewardstyle/go-kinesis.

Not sure if I need to update the Comment. The latest version is still 1.0.1. Not sure what "-21-g7e55cce" means here.