### PR TITLE
Use Auth from meta data if secretKey or authKey is empty string

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,19 @@
+package kinetic
+
+import (
+	"errors"
+	gokinesis "github.com/rewardStyle/go-kinesis"
+)
+
+var MetaAuthenticationErr = errors.New("Authentication error: failed to auth from meta.  Your IAM roles are bad, or you need to specify an AccessKey and SecretKey")
+
+func authenticate(accessKey, secretKey string) (auth *gokinesis.AuthCredentials, err error) {
+	if accessKey == "" || secretKey == "" {
+		if auth, err = gokinesis.NewAuthFromMetadata(); err != nil {
+			return nil, MetaAuthenticationErr
+		}
+	} else {
+		auth = gokinesis.NewAuth(accessKey, secretKey)
+	}
+	return
+}

--- a/firehose.go
+++ b/firehose.go
@@ -62,10 +62,13 @@ func (p *Producer) firehoseFlush(counter *int, timer *time.Time) bool {
 func (p *Producer) Firehose() (*Producer, error) {
 	p.setConcurrency(conf.Concurrency.Producer)
 	p.initChannels()
-
+	auth, err := authenticate(conf.AWS.AccessKey, conf.AWS.SecretKey)
+	if err != nil {
+		return nil, err
+	}
 	p.kinesis = &kinesis{
 		stream: conf.Firehose.Stream,
-		client: gokinesis.NewWithEndpoint(gokinesis.NewAuth(conf.AWS.AccessKey, conf.AWS.SecretKey), conf.AWS.Region, fmt.Sprintf(firehoseURL, conf.AWS.Region)),
+		client: gokinesis.NewWithEndpoint(auth, conf.AWS.Region, fmt.Sprintf(firehoseURL, conf.AWS.Region)),
 	}
 
 	p.producerType = firehoseType
@@ -81,10 +84,13 @@ func (p *Producer) FirehoseC(stream, accessKey, secretKey, region string, concur
 
 	p.setConcurrency(concurrency)
 	p.initChannels()
-
+	auth, err := authenticate(conf.AWS.AccessKey, conf.AWS.SecretKey)
+	if err != nil {
+		return nil, err
+	}
 	p.kinesis = &kinesis{
 		stream: stream,
-		client: gokinesis.NewWithEndpoint(gokinesis.NewAuth(accessKey, secretKey), region, fmt.Sprintf(firehoseURL, region)),
+		client: gokinesis.NewWithEndpoint(auth, region, fmt.Sprintf(firehoseURL, region)),
 	}
 
 	p.producerType = firehoseType

--- a/kinesis.go
+++ b/kinesis.go
@@ -65,14 +65,19 @@ type kinesis struct {
 }
 
 func (k *kinesis) init(stream, shard, shardIteratorType, accessKey, secretKey, region string) (*kinesis, error) {
+
+	auth, err := authenticate(accessKey, secretKey)
+	if err != nil {
+		return nil, err
+	}
 	k = &kinesis{
 		stream:            stream,
 		shard:             shard,
 		shardIteratorType: shardIteratorType,
-		client:            gokinesis.New(gokinesis.NewAuth(accessKey, secretKey), region),
+		client:            gokinesis.New(auth, region),
 	}
 
-	err := k.initShardIterator()
+	err = k.initShardIterator()
 	if err != nil {
 		return k, err
 	}


### PR DESCRIPTION
This is so we can use IAM roles instead of hardcoding auth.