### PR TITLE
Fix nil pointer exception that was missed by the tests

### DIFF
--- a/firehose.go
+++ b/firehose.go
@@ -63,12 +63,12 @@ func (p *Producer) Firehose() (*Producer, error) {
 	p.setConcurrency(conf.Concurrency.Producer)
 	p.initChannels()
 	auth, err := authenticate(conf.AWS.AccessKey, conf.AWS.SecretKey)
-	if err != nil {
-		return nil, err
-	}
 	p.kinesis = &kinesis{
 		stream: conf.Firehose.Stream,
 		client: gokinesis.NewWithEndpoint(auth, conf.AWS.Region, fmt.Sprintf(firehoseURL, conf.AWS.Region)),
+	}
+	if err != nil {
+		return p, err
 	}
 
 	p.producerType = firehoseType
@@ -85,12 +85,12 @@ func (p *Producer) FirehoseC(stream, accessKey, secretKey, region string, concur
 	p.setConcurrency(concurrency)
 	p.initChannels()
 	auth, err := authenticate(conf.AWS.AccessKey, conf.AWS.SecretKey)
-	if err != nil {
-		return nil, err
-	}
 	p.kinesis = &kinesis{
 		stream: stream,
 		client: gokinesis.NewWithEndpoint(auth, region, fmt.Sprintf(firehoseURL, region)),
+	}
+	if err != nil {
+		return p, err
 	}
 
 	p.producerType = firehoseType

--- a/kinesis.go
+++ b/kinesis.go
@@ -67,14 +67,14 @@ type kinesis struct {
 func (k *kinesis) init(stream, shard, shardIteratorType, accessKey, secretKey, region string) (*kinesis, error) {
 
 	auth, err := authenticate(accessKey, secretKey)
-	if err != nil {
-		return nil, err
-	}
 	k = &kinesis{
 		stream:            stream,
 		shard:             shard,
 		shardIteratorType: shardIteratorType,
 		client:            gokinesis.New(auth, region),
+	}
+	if err != nil {
+		return k, err
 	}
 
 	err = k.initShardIterator()

--- a/kinesis_test.go
+++ b/kinesis_test.go
@@ -1,0 +1,24 @@
+package kinetic
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+// TestKineticCreation tests to make sure that the Kinetic creation doesn't return early or return a nil.
+func TestKineticCreation(t *testing.T) {
+	kinesisKinetic, err := new(kinesis).init("fake", "ShardId-00000001", "TRIM_HORIZON", "BADaccessKey", "BADsecretKey", "region")
+
+	Convey("Given an badly configured init-ed kinetic", t, func() {
+		Convey("the error returned should not be nil", func() {
+			So(err, ShouldNotBeNil)
+		})
+		Convey("the returned kinesis struct pointer should not be nil", func() {
+			So(kinesisKinetic, ShouldNotBeNil)
+		})
+		Convey("it should also have some data in it", func() {
+			So(kinesisKinetic.stream, ShouldEqual, "fake")
+			So(kinesisKinetic.shard, ShouldEqual, "ShardId-00000001")
+		})
+	})
+}


### PR DESCRIPTION
My last PR made a nil pointer exception that the tests missed, but could occur under normal use.  This fixes it.
Sorry about that.