### PR TITLE
Make .Close() less greedy, and make sync close too

### DIFF
--- a/listener_test.go
+++ b/listener_test.go
@@ -34,6 +34,25 @@ func TestListenerStop(t *testing.T) {
 	listener.Close()
 }
 
+func TestListenerSyncStop(t *testing.T) {
+	listener, _ := new(Listener).Init()
+	listener.NewEndpoint(testEndpoint, "stream-name")
+
+	Convey("Given a running listener", t, func() {
+		go listener.Listen(func(msg []byte, wg *sync.WaitGroup) {
+			wg.Done()
+		})
+
+		Convey("It should stop listening if sent an interrupt signal", func() {
+			err := listener.CloseSync()
+			So(err, ShouldBeNil)
+			So(listener.IsListening(), ShouldEqual, false)
+		})
+	})
+
+	listener.Close()
+}
+
 func TestListenerError(t *testing.T) {
 	listener, _ := new(Listener).Init()
 	listener.NewEndpoint(testEndpoint, "stream-name")

--- a/producer.go
+++ b/producer.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"strconv"
 	"sync"
 	"syscall"
@@ -365,7 +366,35 @@ func (p *Producer) Close() error {
 	if conf.Debug.Verbose {
 		log.Println("Producer is shutting down.")
 	}
+	runtime.Gosched()
+	return nil
+}
 
+// CloseSync closes the Producer in a syncronous manner.
+func (p *Producer) CloseSync() error {
+	if conf.Debug.Verbose {
+		log.Println("Listener is waiting for all tasks to finish...")
+	}
+	var err error
+	// Stop consuming
+	select {
+	case p.interrupts <- syscall.SIGINT:
+		break
+	default:
+		if conf.Debug.Verbose {
+			log.Println("Already closing listener.")
+		}
+		runtime.Gosched()
+		return err
+	}
+	p.wg.Wait()
+	for p.IsProducing() {
+		runtime.Gosched()
+	}
+	if conf.Debug.Verbose {
+		log.Println("Listener is shutting down.")
+	}
+	runtime.Gosched()
 	return nil
 }
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -35,6 +35,24 @@ func TestProducerStop(t *testing.T) {
 	producer.Close()
 }
 
+func TestSyncStop(t *testing.T) {
+	producer, _ := new(Producer).Init()
+	producer.NewEndpoint(testEndpoint, "stream-name")
+
+	Convey("Given a running producer", t, func() {
+		go producer.produce()
+		runtime.Gosched()
+		Convey("It should stop producing if sent an interrupt signal", func() {
+			err := producer.CloseSync()
+			So(err, ShouldBeNil)
+			// Wait for it to stop
+			So(producer.IsProducing(), ShouldEqual, false)
+		})
+	})
+
+	producer.Close()
+}
+
 func TestProducerError(t *testing.T) {
 	producer, _ := new(Producer).Init()
 	producer.NewEndpoint(testEndpoint, "stream-name")


### PR DESCRIPTION
This makes .Close() less greedy and makes a synchronous close too.