### PR TITLE
Added message count metrics to Producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,11 @@ Session.vim
 *~
 # auto-generated tag files
 tags
+
+### PyCharm ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio
+
+*.iml
+
+## Directory-based project format:
+.idea/

--- a/producer.go
+++ b/producer.go
@@ -63,6 +63,7 @@ type Producer struct {
 	stats Stats
 }
 
+// Stats stores runtime metrics that are queryable via the GetStats call
 type Stats struct {
 	incCount     int64
 	processCount int64


### PR DESCRIPTION
Few notes of the logic and changes applied here:

* I left the counters that are present in the `kinesis` object alone, wanted to get these counters for stats put in first and ensure they work before removing the existing counters and references to them.  Does seem though most of the references are for throttling debug logging, so it is probably safe to change their reference.
* Did not use the `metrics` object we made for the other services because that was more request based and did not fit here.  Did not use the `rcrowley/go-metrics` package because did not want to introduce a 3rd party dependency and its transitive dependencies into a library.  Additionally want to leave the choice of metrics package to the caller of the library, they can pull the `Stats` object from here and push to their metrics package of choice.
* Moved the asynchronous anonymous go func for error handling to the processing loop which is similar style as the rest of the handlers in the processing loop.  Also moved the semaphore release to be in the processing loop and not inside the error handling call.   Wanted to have the semaphore lock and release in the same context area, the processing loop
* Added couple of unexported methods to help with common functionality across methods and provide delegation from the exported methods.   Additionally allows easier metric instrumentation because the counts can be done on the exported methods which act as the public API and the unexported methods can be called multiple times internally without having the counts affected.
* Added instrumentation into the various logic cases to have counters bumped
  * incCount = The count of messages sent to the library
  * processCount = The count of messages processed by library, includes retries
  * retryCount = The count of messages that were retried 
  * succCount = The count of messages that were successfully sent to the streams
  * errCount = The count of messages that errored or unknown state when sent to the streams
  * dropCount = The count of messages that were rejected by the library due to channel full

Should be able to use stats as such 
```
incCount  + retryCount = processCount + dropCount = succCount + errorCount + dropCount
```